### PR TITLE
Reorganization of 'Online Courses' Tab

### DIFF
--- a/app.R
+++ b/app.R
@@ -501,7 +501,7 @@ server <- function(input, output) {
       geom_bar(stat = "identity", na.rm = TRUE) +
       theme_classic() +
       theme(axis.text.x = element_text(angle = 45, hjust=1),
-            legend.position = c(0.9, 0.85),
+            legend.position = "bottom",
             text = element_text(size = 17, family = "Arial")) +
       labs(x = NULL,
            y = "Visitors/Enrollees",

--- a/app.R
+++ b/app.R
@@ -62,79 +62,77 @@ ui <- page_navbar(
   title = "ITN Dashboard",
   fillable = TRUE,
   nav_spacer(),
-  nav_panel("Online Courses",
-            layout_column_wrap(
-              fill = TRUE,
-              width = NULL,
-              style = css(grid_template_columns = "1.2fr 1fr"),
-              navset_card_underline(
-                height = 900,
-                full_screen = TRUE,
-                title = NULL,
-                nav_panel(
-                  "Unique Visitors to Websites",
-                  plotOutput("unique_visitor_website"),
-                  br(),
-                  textOutput("unique_visitor_website_caption"),
-                ),
-                nav_panel(
-                  "Course Engagement by Modality",
-                  plotOutput("engagement_by_modality"),
-                  br(),
-                  textOutput("engagement_by_modality_caption"),
-                ),
-                nav_panel(
-                  "Course Engagement Stats",
-                  plotOutput("engagement_stat"),
-                  br(),
-                  textOutput("engagement_stat_caption")
-                ),
-                nav_panel(
-                  "Learners by Modality",
-                  plotOutput("learner_by_modality"),
-                  br(),
-                  textOutput("learner_by_modality_caption")
-                ),
-                nav_panel(
-                  "Learners by Course",
-                  plotOutput("learner_by_course"),
-                  br(),
-                  textOutput("learner_by_course_caption")
-                ),
-                nav_panel(
-                  "Coursera Learners",
-                  plotOutput("coursera_learner"),
-                  br(),
-                  textOutput("coursera_learner_caption")
-                ),
-                nav_panel(
-                  "Leanpub Learners",
-                  plotOutput("leanpub_learner"),
-                  br(),
-                  textOutput("leanpub_learner_caption")
-                ),
-                nav_panel(
-                  "Learners by Launch Date",
-                  plotOutput("learner_by_launch_date"),
-                  br(),
-                  textOutput("learner_by_launch_date_caption")
-                )
-              ),
-              navset_card_underline(
-                height = 900,
-                full_screen = TRUE,
-                title = "Tables of User Data",
-                nav_panel(
-                  "User Totals",
-                  DTOutput("user_totals")
-                ),
-                nav_panel(
-                  "User Engagement",
-                  DTOutput("user_engagement")
-                )
-              )
-            )
-            
+  nav_menu("Online Courses",
+           nav_panel("Plots",
+                     navset_card_underline(
+                       height = 900,
+                       full_screen = TRUE,
+                       title = NULL,
+                       nav_panel(
+                         "Unique Visitors to Websites",
+                         plotOutput("unique_visitor_website"),
+                         br(),
+                         textOutput("unique_visitor_website_caption"),
+                       ),
+                       nav_panel(
+                         "Course Engagement by Modality",
+                         plotOutput("engagement_by_modality"),
+                         br(),
+                         textOutput("engagement_by_modality_caption"),
+                       ),
+                       nav_panel(
+                         "Course Engagement Stats",
+                         plotOutput("engagement_stat"),
+                         br(),
+                         textOutput("engagement_stat_caption")
+                       ),
+                       nav_panel(
+                         "Learners by Modality",
+                         plotOutput("learner_by_modality"),
+                         br(),
+                         textOutput("learner_by_modality_caption")
+                       ),
+                       nav_panel(
+                         "Learners by Course",
+                         plotOutput("learner_by_course"),
+                         br(),
+                         textOutput("learner_by_course_caption")
+                       ),
+                       nav_panel(
+                         "Coursera Learners",
+                         plotOutput("coursera_learner"),
+                         br(),
+                         textOutput("coursera_learner_caption")
+                       ),
+                       nav_panel(
+                         "Leanpub Learners",
+                         plotOutput("leanpub_learner"),
+                         br(),
+                         textOutput("leanpub_learner_caption")
+                       ),
+                       nav_panel(
+                         "Learners by Launch Date",
+                         plotOutput("learner_by_launch_date"),
+                         br(),
+                         textOutput("learner_by_launch_date_caption")
+                       )
+                     )
+           ),
+           nav_panel("Tables",
+                     navset_card_underline(
+                       height = 900,
+                       full_screen = TRUE,
+                       title = "Tables of User Data",
+                       nav_panel(
+                         "User Totals",
+                         DTOutput("user_totals")
+                       ),
+                       nav_panel(
+                         "User Engagement",
+                         DTOutput("user_engagement")
+                       )
+                     )
+           )
   ),
   nav_panel("Workshops",
             layout_column_wrap(


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

In the 'Online Courses' tab, the plots and tables used to be squished into one page. This meant that if you viewed this page on a small monitor, like your laptop screen, the plots would look squished. Now, the plots are on one page and the tables are on a separate page. 

Also, the legend for the 'Learners by Modality' plot are moved to the bottom, so that they don't overlap with the plot. 

#### What was your approach?

I created two 'sub tabs' within the 'Online Courses' tab: 'Plots' and 'Tables'. The 'Plots' tab contain 8 plots related to Online Courses and the 'Tables' tab contain 2 tables related to Online Courses.


#### What GitHub issue does your pull request address?

https://github.com/FredHutch/itn-dashboard/issues/17

### Tell potential reviewers what kind of feedback you are soliciting.

Whether this setup makes the dashboard easier to navigate and the plots/tables in the 'Online Courses' tab don't look squished. 
