### PR TITLE
Add collaboration plot that colors by collaborator affiliation

### DIFF
--- a/app.R
+++ b/app.R
@@ -166,6 +166,11 @@ ui <- dashboardPage(
                     plotOutput("plot_collaboration_all")),
                 box(title = "ITCR-Only Collaborations",
                     plotOutput("plot_collaboration_itcr"))
+              ),
+              #Second Row
+              fluidRow(
+                box(title = "All Collaborations: Specifying Affiliation",
+                    plotOutput("plot_collaboration_all_color"))
               )
       ),
       # About Tab ----------------------------------------------------
@@ -434,7 +439,7 @@ server <- function(input, output) {
       ggplot(aes(x = website, y = value, fill = target_audience)) +
       geom_bar(position = "dodge", stat = "identity") +
       geom_text(aes(label = round(value, 1), hjust = -0.2)) +
-      coord_flip(clip='off') +
+      coord_flip(clip="off") +
       theme_classic() +
       labs(x = NULL,
            y = NULL,
@@ -566,7 +571,7 @@ server <- function(input, output) {
         nudge_y = .5,
         color = "black"
       )
-      })
+  })
 
   # Plot: Workshop Recommendation ----------------------------------------------------
   output$plot_workshop_recommendation <- renderPlot({
@@ -695,6 +700,38 @@ server <- function(input, output) {
             plot.margin = unit(c(.75,.5,.5,.5), "cm")) +
       xlab(NULL) +
       ylab(NULL)
+  })
+  
+  # Plot: All Collaborations colored by ITCR or not ------------------------------
+  output$plot_collaboration_all_color <- renderPlot({
+    collabs_processed() %>%
+      group_by(Category, ITN_ITCR_or_external) %>%
+      mutate(ITN_ITCR_or_external = 
+               factor(case_when(ITN_ITCR_or_external == "external" ~ "Not ITCR",
+                                ITN_ITCR_or_external == "external (was after leaving)" ~ "Not ITCR",
+                                ITN_ITCR_or_external == "external NIH/NCI intermural" ~ "Not ITCR",
+                                ITN_ITCR_or_external == "ITCR" ~ "ITCR",
+                                ITN_ITCR_or_external == "ITN" ~ "ITN",
+                                ITN_ITCR_or_external == "NCI" ~ "Not ITCR",
+                                ITN_ITCR_or_external == "neither" ~ "Not ITCR",
+                                ITN_ITCR_or_external == "NIH" ~ "Not ITCR"),
+                      levels = rev(c("ITCR", "Not ITCR", "ITN")))) %>%
+      summarize(n= n()) %>%
+      ggplot(aes(y = n, x = reorder(Category,-n, sum), fill = ITN_ITCR_or_external)) +
+      geom_bar(position = "stack", stat = "identity") +
+      geom_text(aes(label = after_stat(y), group = Category), hjust = -0.2,
+                stat = 'summary', fun = sum) +
+      coord_flip(clip = "off") +
+      theme_classic() +
+      labs(fill = "ITCR Collab?") +
+      theme(strip.text.x = element_text(size = 6),
+            legend.position="inside",
+            legend.position.inside = c(0.75, 0.75),
+            text = element_text(size = 17, family = "Arial"),
+            plot.margin = unit(c(.75,.5,.5,.5), "cm")) + 
+      xlab(NULL) +
+      ylab(NULL) +
+      scale_fill_discrete(na.translate = F)
   })
 
 

--- a/app.R
+++ b/app.R
@@ -725,9 +725,9 @@ server <- function(input, output) {
       summarize(n= n()) %>%
       ggplot(aes(y = n, x = reorder(Category,-n, sum), fill = ITN_ITCR_or_external)) +
       geom_bar(position = "stack", stat = "identity") +
-      geom_text(aes(label = after_stat(y), group = Category), hjust = 1.1,
+      geom_text(aes(label = after_stat(y), group = Category), hjust = 1.05,
                 stat = 'summary', fun = sum,
-                colour = "white") +
+                colour = "white", fontface = "bold") +
       coord_flip() +
       theme_classic() +
       labs(fill = "ITCR Collab?") +

--- a/app.R
+++ b/app.R
@@ -719,9 +719,10 @@ server <- function(input, output) {
       summarize(n= n()) %>%
       ggplot(aes(y = n, x = reorder(Category,-n, sum), fill = ITN_ITCR_or_external)) +
       geom_bar(position = "stack", stat = "identity") +
-      geom_text(aes(label = after_stat(y), group = Category), hjust = -0.2,
-                stat = 'summary', fun = sum) +
-      coord_flip(clip = "off") +
+      geom_text(aes(label = after_stat(y), group = Category), hjust = 1.1,
+                stat = 'summary', fun = sum,
+                colour = "white") +
+      coord_flip() +
       theme_classic() +
       labs(fill = "ITCR Collab?") +
       theme(strip.text.x = element_text(size = 6),


### PR DESCRIPTION
:warning: This is a stacked PR based on #24 :warning: that adds a plot to the collaborations tab

The plot shows all collaborations and colors by affiliation (ITCR, not ITCR, ITN) and is meant as a supplement to the other two collaboration plots. 

I verified that the app ran locally and the plot displayed as I expected on my branch