### PR TITLE
Add color and dashed line for metricminer in plot

### DIFF
--- a/app.R
+++ b/app.R
@@ -21,7 +21,7 @@ cbPalette <- c("#E69F02", "#56B4E9", "#009E73", "#008080")
 
 xlabel_view <- c(rep(c("black", "transparent", "transparent", "transparent"), 41), "black", "transparent") #166 rows
 #cc <- rev(c("#fde725", "#addc30", "#5ec962", "#28ae80", "#21918c", "#2c728e", "#3b528b", "#472d7b", "#440154"))
-viridis_cc <- c("#440154", "#2c728e", "#28ae80", "#addc30")
+viridis_cc <- c("#440154", "#2c728e", "#fde725", "#28ae80", "#addc30")
 
 # Wordcloud 
 ud_model <- udpipe::udpipe_load_model("wordcloud-model.udpipe")
@@ -641,6 +641,7 @@ server <- function(input, output) {
       geom_vline(aes(xintercept = "2019-05"), linetype='dashed', color = '#addc30') + #text2speech published date
       geom_vline(aes(xintercept="2022-02"), linetype='dashed', color = '#28ae80') + #ottrpal published date 
       geom_vline(aes(xintercept="2023-07"), linetype='dashed', color = '#2c728e') + #conrad published date
+      geom_vline(aes(xintercept="2024-02"), linetype="dashed", color = '#fde725') + #metricminer published date
       theme(axis.text.x = element_text(angle = 90),
             legend.position = "bottom") + #clean up x-axis labels
       labs(x = NULL,

--- a/app.R
+++ b/app.R
@@ -168,7 +168,8 @@ ui <- dashboardPage(
               fluidRow(
                 box(title = "Monthly CRAN Downloads",
                     width = 12,
-                    plotOutput("plot_monthly_cran_download"))
+                    plotOutput("plot_monthly_cran_download"),
+                    footer = "*Dashed vertical lines denote when software was published on CRAN.")
               )
       ),
       # Collaborations Tab ----------------------------------------------------


### PR DESCRIPTION
Added a color to `viridis_cc` since there's another package that will be in the plot
Also added a dashed vertical line to go along with the publish date for metricminer.

I know that the colors of the software download lines in the plot don't currently match the colors of the dashed/posted on cran vertical lines. That's because I added the new color in the middle of the `viridis_cc` vector since alphabetically I think it goes ari, conrad, metricminer, ottrpal, text2speech and figured it would be the least number of changes to just add a color and a vertical line that matches that color instead of adjusting all the other colors.

Also added a commit that adds a footer description below the plot describing what the dashed vertical lines are