### PR TITLE
remove Using Leanpub Course from view

### DIFF
--- a/.github/workflows/get_itn_data.R
+++ b/.github/workflows/get_itn_data.R
@@ -41,7 +41,7 @@ itcr_stats <- itcr_stats_raw$metrics
 
 # Filter out Google Analytics that aren't ITCR courses
 not_itcr <- c("hutchdatasci", "whoiswho", "MMDS", "FH Cluster 101", "DaSL Collection",  "proof",
-              "Developing_WDL_Workflows", "ITN Website", "OTTR website", "metricminer.org", "widget")
+              "Developing_WDL_Workflows", "ITN Website", "OTTR website", "metricminer.org", "widget", "Using Leanpub Course")
 
 # itcr_ga_metric_data.csv ----------------------------------------------------
 itcr_ga_metric_data <- fhdsl_stats %>%

--- a/app.R
+++ b/app.R
@@ -387,7 +387,7 @@ server <- function(input, output) {
       # Filter out ITN Website since it is not an "Educational Resource"
       filter(!(website %in% c("ITN Website", "widget", "DaSL Collection",
                               "proof", "metricminer.org", "OTTR website",
-                              "Developing_WDL_Workflows"))) %>%
+                              "Developing_WDL_Workflows", "Using Leanpub Course"))) %>%
       ggplot(aes(x = reorder(website, -totalUsers), y = totalUsers, fill = target_audience)) +
       geom_bar(stat = "identity") +
       geom_text(aes(label = totalUsers), hjust = 1.05,
@@ -458,7 +458,7 @@ server <- function(input, output) {
   # Plot: Course Engagement by Target Audience ----------------------------------------------------
   output$plot_engagement_target <- renderPlot({
     itcr_course_data_long() %>%
-      filter(!(website %in% c("widget", "DaSL Collection", "Developing_WDL_Workflows", "proof"))) %>%
+      filter(!(website %in% c("widget", "DaSL Collection", "Developing_WDL_Workflows", "proof", "Using Leanpub Course"))) %>%
       group_by(modality, target_audience) %>%
       summarize(total_learners = sum(learner_count, na.rm = TRUE)) %>%
       ggplot(aes(x = reorder(modality, -total_learners), y = total_learners, fill = target_audience)) +
@@ -482,7 +482,7 @@ server <- function(input, output) {
     itcr_course_data_long() %>%
       group_by(website, target_audience) %>%
       summarize(total_learners = sum(learner_count, na.rm = TRUE)) %>%
-      filter(!(website %in% c("widget", "DaSL Collection", "Developing_WDL_Workflows", "proof"))) %>%
+      filter(!(website %in% c("widget", "DaSL Collection", "Developing_WDL_Workflows", "proof", "Using Leanpub Course"))) %>%
       ggplot(aes(x = reorder(website, -total_learners), y = total_learners, fill = target_audience)) +
       geom_bar(stat = "identity") +
       geom_text(aes(label = total_learners), hjust = 1.05, na.rm = TRUE,


### PR DESCRIPTION
There was an error with a few plots rendering and it was because "Using Leanpub Course" seems to be on google analytics now and that gets pulled in as an "everyone" audience course so I had to filter it out. 